### PR TITLE
add a bin command to find all requires on a file

### DIFF
--- a/bin/reqursive.js
+++ b/bin/reqursive.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+var parseArgs = require('minimist');
+var path = require('path');
+
+var reqursive = require('../index.js');
+
+function main(opts) {
+    var fileName = path.resolve(opts._[0]);
+    var dirName = path.dirname(fileName);
+
+    reqursive(fileName, {
+        traverseModules: false
+    }, function (err, files) {
+        if (err) {
+            throw err;
+        }
+
+        var nonModules = files.filter(function (file) {
+            return !file.module && !file.mgroup;
+        }).map(function (file) {
+            return path.join(dirName, file.filename);
+        });
+
+        console.log(nonModules.join('\n'));
+    });
+}
+
+if (require.main === module) {
+    main(parseArgs(process.argv.slice(2)));
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "detective": "~0.2.1",
     "async": "~0.1.22",
-    "nub": "0.0.0"
+    "nub": "0.0.0",
+    "minimist": "0.0.8"
   },
   "description": "Take a file and recursively discover all the files loaded in using `require()`.",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "mocha": "~1.6.0"
   },
+  "bin": "./bin/reqursive.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/hughsk/reqursive.git"


### PR DESCRIPTION
When pointing at a file `reqursive app.js` it find all require callsites that are not node_modules.
